### PR TITLE
Create a proper working Linux makefile

### DIFF
--- a/src/HexRaysCodeXplorer/makefile.lnx
+++ b/src/HexRaysCodeXplorer/makefile.lnx
@@ -31,7 +31,7 @@ else
 	LIBS= -lida -lc -lpthread -ldl
 endif
 
-all: check-env HexRaysCodeXplorer.$(EXT)
+all: check-env clean HexRaysCodeXplorer.$(EXT)
 
 HexRaysCodeXplorer.$(EXT): $(OBJS)	
 	$(CC) $(LDFLAGS) $(LIBDIR) -o HexRaysCodeXplorer.$(EXT) $(OBJS) $(LIBS)

--- a/src/HexRaysCodeXplorer/makefile.lnx
+++ b/src/HexRaysCodeXplorer/makefile.lnx
@@ -1,0 +1,58 @@
+# use this makefile to build HexRaysCodeXplorer for Linux
+
+CC=g++
+LD=ld
+
+LDFLAGS=-shared -m32 -static-libgcc -static-libstdc++
+
+LIBDIR=-L$(shell pwd) -L$(IDA_DIR)
+SRCDIR=./
+HEXRAYS_SDK=$(IDA_DIR)/plugins/hexrays_sdk
+SRC=$(SRCDIR)CodeXplorer.cpp \
+	$(SRCDIR)CtreeGraphBuilder.cpp \
+	$(SRCDIR)ObjectExplorer.cpp \
+	$(SRCDIR)TypeReconstructor.cpp \
+	$(SRCDIR)CtreeExtractor.cpp \
+	$(SRCDIR)TypeExtractor.cpp \
+	$(SRCDIR)Utility.cpp \
+	$(SRCDIR)ObjectFormatMSVC.cpp \
+	$(SRCDIR)Debug.cpp
+OBJS=$(subst .cpp,.o,$(SRC))
+EXECUTABLE=HexRaysCodeXplorer
+INCLUDES=-I$(IDA_SDK)/include -I$(HEXRAYS_SDK)/include
+
+ifeq ($(EA64),1)
+	CFLAGS=-m32 -fPIC -D__LINUX__ -D__PLUGIN__ -D__EA64__ -std=c++11
+	EXT=plx64
+	LIBS= -lida64 -lc -lpthread -ldl
+else
+	CFLAGS=-m32 -D__LINUX__ -D__PLUGIN__ -std=c++11
+	EXT=plx
+	LIBS= -lida -lc -lpthread -ldl
+endif
+
+all: check-env HexRaysCodeXplorer.$(EXT)
+
+HexRaysCodeXplorer.$(EXT): $(OBJS)	
+	$(CC) $(LDFLAGS) $(LIBDIR) -o HexRaysCodeXplorer.$(EXT) $(OBJS) $(LIBS)
+
+%.o: %.cpp
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) HexRaysCodeXplorer.$(EXT)
+
+install:
+	cp -f HexRaysCodeXplorer.$(EXT) $(IDA_DIR)/plugins
+
+check-env:
+ifndef IDA_SDK
+    $(error IDA_SDK is undefined)
+endif
+ifndef IDA_DIR
+    $(error IDA_DIR is undefined)
+endif
+ifndef EA64
+    $(error specify EA64=0 for 32 bit build or EA64=1 for 64 bit build)
+endif
+.PHONY: check-env

--- a/src/HexRaysCodeXplorer/makefile.lnx
+++ b/src/HexRaysCodeXplorer/makefile.lnx
@@ -5,7 +5,7 @@ LD=ld
 
 LDFLAGS=-shared -m32 -static-libgcc -static-libstdc++
 
-LIBDIR=-L$(shell pwd) -L$(IDA_DIR)
+LIBDIR=-L$(IDA_DIR)
 SRCDIR=./
 HEXRAYS_SDK=$(IDA_DIR)/plugins/hexrays_sdk
 SRC=$(SRCDIR)CodeXplorer.cpp \


### PR DESCRIPTION
This PR creates a proper Linux makefile. I didn't remove the Linux targets from the old makefile, as I don't want to break the Mac builds - I also think the Mac builds need some love, but I don't have a Mac.

This new makefile builds correctly HexRaysCodeXplorer on Linux, to build for 32 bit simply set EA64=0, for 64 bit set EA64=1.
To build use make -f makefile.lnx.

Tested and working for both 32 and 64 bit.