### PR TITLE
Cleanup & fixes

### DIFF
--- a/src/HexRaysCodeXplorer/CodeXplorer.cpp
+++ b/src/HexRaysCodeXplorer/CodeXplorer.cpp
@@ -484,7 +484,7 @@ static bool idaapi show_offset_in_windbg_format(void *ud) {
 	show_string_in_custom_view(&vu, title, result);
 
 #if defined (__LINUX__) || defined (__MAC__)
-	msg(result.c_str());
+	msg("%s", result.c_str());
 #else
 	OpenClipboard(0);
 	EmptyClipboard();

--- a/src/HexRaysCodeXplorer/CodeXplorer.cpp
+++ b/src/HexRaysCodeXplorer/CodeXplorer.cpp
@@ -393,7 +393,7 @@ static bool get_expr_name(citem_t *citem, qstring& rv)
 	cexpr_t *e = (cexpr_t *)citem;
 
 	// retrieve the name of the routine
-	e->print1(&rv, NULL);
+	print1wrapper(e, &rv, NULL);
 	tag_remove(&rv);
 
 	return true;
@@ -705,7 +705,7 @@ int idaapi init(void)
 	for (unsigned i = 0; i < _countof(kActionDescs); ++i)
 		register_action(kActionDescs[i]);
 
-	install_hexrays_callback(callback, nullptr);
+	install_hexrays_callback((hexrays_cb_t*)callback, nullptr);
 	logmsg(INFO, "Hex-rays version %s has been detected\n", get_hexrays_version());
 	inited = true;
 
@@ -742,7 +742,7 @@ void idaapi term(void)
 	if (inited)
 	{
 		logmsg(INFO, "\nHexRaysCodeXplorer plugin by @REhints terminated.\n\n\n");
-		remove_hexrays_callback(callback, NULL);
+		remove_hexrays_callback((hexrays_cb_t*)callback, NULL);
 		term_hexrays_plugin();
 	}
 }

--- a/src/HexRaysCodeXplorer/Common.h
+++ b/src/HexRaysCodeXplorer/Common.h
@@ -44,7 +44,16 @@
 #pragma warning(push)
 #pragma warning(disable:4309 4244 4267)           // disable "truncation of constant value" warning from IDA SDK, conversion from 'ssize_t' to 'int', possible loss of data
 #endif // __NT__
+#ifndef USE_DANGEROUS_FUNCTIONS
 #define USE_DANGEROUS_FUNCTIONS
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wvarargs"
+#pragma clang diagnostic ignored "-Wlogical-op-parentheses"
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
 #include <hexrays.hpp>
 #include <ida.hpp>
 #include <idp.hpp>
@@ -66,6 +75,9 @@
 #ifdef __NT__
 #pragma warning(pop)
 #endif // __NT__
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #include <cstring>
 #include <cstdarg>

--- a/src/HexRaysCodeXplorer/CtreeExtractor.cpp
+++ b/src/HexRaysCodeXplorer/CtreeExtractor.cpp
@@ -139,7 +139,7 @@ void ctree_dumper_t::parse_ctree_item(citem_t *item, qstring& rv) const
 		rv.append(' ');
 		{
 			qstring qbuf;
-			e->print1(&qbuf, NULL);
+			print1wrapper(e, &qbuf, NULL);
 			tag_remove(&qbuf);
 			rv += qbuf;
 		}

--- a/src/HexRaysCodeXplorer/CtreeExtractor.cpp
+++ b/src/HexRaysCodeXplorer/CtreeExtractor.cpp
@@ -112,7 +112,7 @@ void ctree_dumper_t::parse_ctree_item(citem_t *item, qstring& rv) const
 	{
 	case cot_call:
 		if (e->x->op == cot_obj) {
-			if (get_func_name(&func_name, e->x->obj_ea) == NULL)
+			if (get_func_name(&func_name, e->x->obj_ea) == 0)
 				rv.cat_sprnt(" sub_%a", e->x->obj_ea);
 			else 
 				rv.cat_sprnt(" %s", func_name.c_str());
@@ -390,7 +390,7 @@ bool idaapi extract_all_ctrees(void *ud)
 	va_end(va);
 
 	qstring crypto_prefix = kDefaultPrefix;
-	if (!ask_str(&crypto_prefix, NULL, "Enter prefix of crypto function names", va))
+	if (!ask_str(&crypto_prefix, 0, "Enter prefix of crypto function names", va))
 		return false;
 
 	if(!crypto_prefix.empty()) {

--- a/src/HexRaysCodeXplorer/CtreeExtractor.cpp
+++ b/src/HexRaysCodeXplorer/CtreeExtractor.cpp
@@ -262,14 +262,14 @@ void dump_ctrees_in_file(std::map<ea_t, ctree_dump_line> &data_to_dump, const qs
 		dump_line.cat_sprnt(";%08X", cdl.func_start);
 		dump_line.cat_sprnt(";%08X", cdl.func_end);
 		if ((cdl.func_name.length() > crypt_prefix_len) && (crypt_prefix_len > 0) && (cdl.func_name.find(crypto_prefix) == 0))
-			dump_line.cat_sprnt(";E", cdl.func_end);
+			dump_line.cat_sprnt(";E");
 		else
-			dump_line.cat_sprnt(";N", cdl.func_end);
+			dump_line.cat_sprnt(";N");
 
 		if ((cdl.heuristic_flag))
-			dump_line.cat_sprnt(";H", cdl.func_end);
+			dump_line.cat_sprnt(";H");
 		else
-			dump_line.cat_sprnt(";N", cdl.func_end);
+			dump_line.cat_sprnt(";N");
 
 		dump_line += "\n";
 

--- a/src/HexRaysCodeXplorer/CtreeGraphBuilder.cpp
+++ b/src/HexRaysCodeXplorer/CtreeGraphBuilder.cpp
@@ -102,7 +102,7 @@ void callgraph_t::get_node_label(int n, qstring& rv) const
 			rv.append(' ');
 			{
 				qstring qbuf;
-				e->print1(&qbuf, nullptr);
+				print1wrapper(e, &qbuf, nullptr);
 				tag_remove(&qbuf);
 				rv += qbuf;
 			}

--- a/src/HexRaysCodeXplorer/CtreeGraphBuilder.h
+++ b/src/HexRaysCodeXplorer/CtreeGraphBuilder.h
@@ -73,7 +73,7 @@ public:
 
 	callgraph_t();
 
-	const int count() const { return node_count; }
+	int count() const { return node_count; }
 
 	// node / func info
 	struct nodeinfo_t

--- a/src/HexRaysCodeXplorer/GCCObjectFormatParser.h
+++ b/src/HexRaysCodeXplorer/GCCObjectFormatParser.h
@@ -8,7 +8,7 @@ namespace GCC_RTTI {
 #pragma pack(push, 1)
 
 	struct __vtable_info {
-		size_t ptrdiff;
+		ssize_t ptrdiff;
 		ea_t type_info;
 		ea_t origin[1];
 	};

--- a/src/HexRaysCodeXplorer/GCCTypeInfo.cpp
+++ b/src/HexRaysCodeXplorer/GCCTypeInfo.cpp
@@ -3,7 +3,10 @@
 #include "offset.hpp"
 #include "Utility.h"
 
-
+#if __clang__
+// Ignore "offset of on non-standard-layout type" warning
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
+#endif
 
 
 GCCTypeInfo::GCCTypeInfo()

--- a/src/HexRaysCodeXplorer/Linux.h
+++ b/src/HexRaysCodeXplorer/Linux.h
@@ -38,8 +38,8 @@
 #define BOOL bool
 #define TRUE true
 #define FALSE false
-#define LPCSTR char *const
-#define LPCTSTR char *const
+#define LPCSTR const char *
+#define LPCTSTR const char *
 #define LPSTR char *
 #define WORD uint16_t
 #define DWORD uint32_t

--- a/src/HexRaysCodeXplorer/TypeExtractor.cpp
+++ b/src/HexRaysCodeXplorer/TypeExtractor.cpp
@@ -62,7 +62,7 @@ int idaapi obj_fint_t::visit_expr(cexpr_t *e)
 
 	// get the variable name
 	qstring s;
-	e->print1(&s, NULL);
+	print1wrapper(e, &s, NULL);
 	tag_remove(&s);
 
 	// check for the target variable
@@ -84,7 +84,7 @@ int idaapi obj_fint_t::visit_expr(cexpr_t *e)
 
 			if (target_expr->op == cot_var) {
 				s.clear();
-				target_expr->print1(&s, NULL);
+				print1wrapper(target_expr, &s, NULL);
 				tag_remove(&s);
 
 				var_name = s;
@@ -137,7 +137,7 @@ bool idaapi find_var(void *ud)
 		cexpr_t *highl_expr = (cexpr_t *)highlight;
 
 		qstring s;
-		highlight->print1(&s, NULL);
+		print1wrapper(highlight, &s, NULL);
 		tag_remove(&s);
 
 		// initialize type rebuilder

--- a/src/HexRaysCodeXplorer/TypeExtractor.cpp
+++ b/src/HexRaysCodeXplorer/TypeExtractor.cpp
@@ -99,7 +99,7 @@ int idaapi obj_fint_t::visit_expr(cexpr_t *e)
 
 void idaapi reset_pointer_type(cfuncptr_t cfunc, const qstring &var_name) {
 	lvars_t * locals = cfunc->get_lvars();
-	if (!locals != NULL)
+	if (locals == NULL)
 		return;
 
 	qvector<lvar_t>::iterator locals_iter;

--- a/src/HexRaysCodeXplorer/TypeExtractor.cpp
+++ b/src/HexRaysCodeXplorer/TypeExtractor.cpp
@@ -296,7 +296,7 @@ void idaapi dump_type_info(int file_id, const VTBL_info_t& vtbl_info, const qstr
 		qstring line;
 
 		line = key_hash + ";" + file_entry_key + ";";
-		line.cat_sprnt("%p;", vtbl_info.ea_begin);
+		line.cat_sprnt("%a;", vtbl_info.ea_begin);
 		line += file_entry_val + ";";
 
 		if (rtti_vftables.count(vtbl_info.ea_begin) != 0) {
@@ -311,7 +311,7 @@ void idaapi dump_type_info(int file_id, const VTBL_info_t& vtbl_info, const qstr
 
 bool idaapi check_subtype(VTBL_info_t vtbl_info, qstring subtype_name) {
 	qstring search_str;
-	search_str.sprnt("_%p", vtbl_info.ea_begin);
+	search_str.sprnt("_%a", vtbl_info.ea_begin);
 
 	struc_t * struc_type = get_struc(get_struc_id(subtype_name.c_str()));
 	if (!struc_type)
@@ -399,7 +399,7 @@ bool idaapi extract_all_types(void *ud)
 					}
 				}
 				else {
-					info_msg.cat_sprnt(" : none\n", var_name.c_str());
+					info_msg.cat_sprnt(" : none\n");
 					logmsg(DEBUG, info_msg.c_str());
 				}
 			}

--- a/src/HexRaysCodeXplorer/TypeReconstructor.cpp
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.cpp
@@ -597,7 +597,7 @@ bool idaapi reconstruct_type_cb(void *ud)
 			if (!type_bldr.structure.empty() && lvar != NULL)
 			{
 				qstring type_name{ "struct_name" };
-				if (!ask_str(&type_name, NULL, "Enter type name:"))
+				if (!ask_str(&type_name, 0, "Enter type name:"))
 					return false;
 
 				if (!type_name.empty())

--- a/src/HexRaysCodeXplorer/TypeReconstructor.cpp
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.cpp
@@ -597,6 +597,8 @@ bool idaapi reconstruct_type_cb(void *ud)
 			if (!type_bldr.structure.empty() && lvar != NULL)
 			{
 				qstring type_name{ "struct_name" };
+				if (lvar->type().is_ptr()) // doesn't make sense if it's not tbh
+					(void)lvar->type().get_pointed_object().get_type_name(&type_name);
 				if (!ask_str(&type_name, 0, "Enter type name:"))
 					return false;
 

--- a/src/HexRaysCodeXplorer/TypeReconstructor.cpp
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.cpp
@@ -184,7 +184,7 @@ bool idaapi type_builder_t::check_helper(citem_t *parent, int &off, int &num)
 		if(!strcmp(get_ctype_name(expr_2->x->op), "helper"))
 		{
 			qstring expr;
-			expr_2->x->print1(&expr, NULL);
+			print1hack(expr_2->x, &expr, NULL);
 			tag_remove(&expr);
 
 			if(expr == "LOBYTE")
@@ -326,7 +326,7 @@ bool idaapi type_builder_t::check_ptr(cexpr_t *e, struct_filed &str_fld)
 
 				// get index_value
 				qstring s;
-				expr_2->y->print1(&s, NULL);
+				print1hack(expr_2->y, &s, NULL);
 				tag_remove(&s);
 
 				int base = 10;
@@ -358,7 +358,7 @@ bool idaapi type_builder_t::check_ptr(cexpr_t *e, struct_filed &str_fld)
 			} else if(parent_i->is_expr() && (parent_i->op == cot_asg)) {
 				if (((cexpr_t *)parent_i)->y == e) { //parents[parents.size() - i]) {
 					qstring s;
-					((cexpr_t *)parent_i)->x->print1(&s, NULL);
+					print1hack(((cexpr_t *)parent_i)->x, &s, NULL);
 					tag_remove(&s);
 
 					char comment[258];
@@ -422,7 +422,7 @@ bool idaapi type_builder_t::check_idx(struct_filed &str_fld)
 
 				// get index_value
 				qstring s;
-				expr_2->y->print1(&s, NULL);
+				print1hack(expr_2->y, &s, NULL);
 				tag_remove(&s);
 				int num = atoi(s.c_str());
 
@@ -454,7 +454,7 @@ int idaapi type_builder_t::visit_expr(cexpr_t *e)
 	{
 		// get the variable name
 		qstring s;
-		e->print1(&s, NULL);
+		print1hack(e, &s, NULL);
 		tag_remove(&s);
 
 		// check for the target variable
@@ -586,7 +586,7 @@ bool idaapi reconstruct_type_cb(void *ud)
 			type_builder_t type_bldr;
 			{
 				qstring s;
-				highl_expr->print1(&s, NULL);
+				print1hack(highl_expr, &s, NULL);
 				tag_remove(&s);
 				type_bldr.expression_to_match.insert(s);
 			}
@@ -612,7 +612,7 @@ bool idaapi reconstruct_type_cb(void *ud)
 							if (new_type.print(&type_str, NULL, PRTYPE_DEF | PRTYPE_MULTI))
 							{
 								msg("New type created:\r\n%s\n", type_str.c_str());
-								logmsg(DEBUG, ("New type created:\r\n%s\n", type_str.c_str()));
+								logmsg(DEBUG, "New type created:\r\n%s\n", type_str.c_str());
 								tinfo_t ptype = make_pointer(new_type);
 								vu.set_lvar_type(lvar, ptype);
 								vu.refresh_ctext();
@@ -654,7 +654,7 @@ bool idaapi reconstruct_type(cfuncptr_t cfunc, const qstring& var_name, const qs
 			if(new_type.is_correct()) {
 				qstring type_str = type_name;
 				//if (new_type.print(&type_str, NULL, PRTYPE_DEF | PRTYPE_MULTI))
-				logmsg(DEBUG, ("New type created: %s\n", type_str.c_str()));
+				logmsg(DEBUG, "New type created: %s\n", type_str.c_str());
 
 				bResult = true;
 			}

--- a/src/HexRaysCodeXplorer/TypeReconstructor.cpp
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.cpp
@@ -494,6 +494,12 @@ int type_builder_t::get_structure_size()
 tid_t type_builder_t::get_structure(const qstring& name)
 {
 	tid_t struct_type_id = add_struc(BADADDR, name.c_str());
+
+	if (struct_type_id == BADADDR) {
+		// the name is ill-formed or *is already used in the program*
+		struct_type_id = get_struc_id(name.c_str());
+	}
+
 	if (struct_type_id != BADADDR)
 	{
 		struc_t * struc = get_struc(struct_type_id);

--- a/src/HexRaysCodeXplorer/TypeReconstructor.cpp
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.cpp
@@ -184,7 +184,7 @@ bool idaapi type_builder_t::check_helper(citem_t *parent, int &off, int &num)
 		if(!strcmp(get_ctype_name(expr_2->x->op), "helper"))
 		{
 			qstring expr;
-			print1hack(expr_2->x, &expr, NULL);
+			print1wrapper(expr_2->x, &expr, NULL);
 			tag_remove(&expr);
 
 			if(expr == "LOBYTE")
@@ -326,7 +326,7 @@ bool idaapi type_builder_t::check_ptr(cexpr_t *e, struct_filed &str_fld)
 
 				// get index_value
 				qstring s;
-				print1hack(expr_2->y, &s, NULL);
+				print1wrapper(expr_2->y, &s, NULL);
 				tag_remove(&s);
 
 				int base = 10;
@@ -358,7 +358,7 @@ bool idaapi type_builder_t::check_ptr(cexpr_t *e, struct_filed &str_fld)
 			} else if(parent_i->is_expr() && (parent_i->op == cot_asg)) {
 				if (((cexpr_t *)parent_i)->y == e) { //parents[parents.size() - i]) {
 					qstring s;
-					print1hack(((cexpr_t *)parent_i)->x, &s, NULL);
+					print1wrapper(((cexpr_t *)parent_i)->x, &s, NULL);
 					tag_remove(&s);
 
 					char comment[258];
@@ -422,7 +422,7 @@ bool idaapi type_builder_t::check_idx(struct_filed &str_fld)
 
 				// get index_value
 				qstring s;
-				print1hack(expr_2->y, &s, NULL);
+				print1wrapper(expr_2->y, &s, NULL);
 				tag_remove(&s);
 				int num = atoi(s.c_str());
 
@@ -454,7 +454,7 @@ int idaapi type_builder_t::visit_expr(cexpr_t *e)
 	{
 		// get the variable name
 		qstring s;
-		print1hack(e, &s, NULL);
+		print1wrapper(e, &s, NULL);
 		tag_remove(&s);
 
 		// check for the target variable
@@ -592,7 +592,7 @@ bool idaapi reconstruct_type_cb(void *ud)
 			type_builder_t type_bldr;
 			{
 				qstring s;
-				print1hack(highl_expr, &s, NULL);
+				print1wrapper(highl_expr, &s, NULL);
 				tag_remove(&s);
 				type_bldr.expression_to_match.insert(s);
 			}


### PR DESCRIPTION
- Reduce amount of warnings when building with clang (also fixes some issues/bugs spotted by those warnings)
- Make it build for both HexRays7 (IDA7.0) and HexRays8 (IDA8.0) by wrapping print1 calls in template and casting `callback` in install/remove HexRays callback
- Fix #18
- Show current type instead of "struct_name" when possible
- Allow Reconstruct Type when local variable (or arg) is selected, not just on expressions