### PR TITLE
Fix std::max call, vtable auto assignment, and Microcode View hotkey cfg

### DIFF
--- a/src/HexRaysCodeXplorer/CodeXplorer.cpp
+++ b/src/HexRaysCodeXplorer/CodeXplorer.cpp
@@ -726,7 +726,7 @@ namespace {
 		cfgopt_t("HOTKEY_EXTRACT_TYPES", hotkey_et, (size_t)sizeof(hotkey_et), false),
 		cfgopt_t("HOTKEY_EXTRACT_CTREE", hotkey_ec, (size_t)sizeof(hotkey_ec), false),
 		cfgopt_t("HOTKEY_CTREE_EXPLORER", hotkey_vc, (size_t)sizeof(hotkey_vc), false),
-		cfgopt_t("HOTKEY_MICROCODE_EXPLORER", hotkey_vc, (size_t)sizeof(hotkey_mc), false),
+		cfgopt_t("HOTKEY_MICROCODE_EXPLORER", hotkey_mc, (size_t)sizeof(hotkey_mc), false),
 		cfgopt_t("HOTKEY_SHOW_COPY_ITEM_OFFSET", hotkey_so, (size_t)sizeof(hotkey_so), false),
 		cfgopt_t("HOTKEY_RENAME_VARS", hotkey_rv, (size_t)sizeof(hotkey_rv), false)
 	};

--- a/src/HexRaysCodeXplorer/GCCObjectFormatParser.cpp
+++ b/src/HexRaysCodeXplorer/GCCObjectFormatParser.cpp
@@ -228,8 +228,8 @@ void GCCObjectFormatParser::get_rtti_info()
 
 void GCCObjectFormatParser::scanSeg4Vftables(segment_t *seg)
 {
-	size_t size = std::max(sizeof(GCC_RTTI::__vtable_info), sizeof(GCC_RTTI::type_info));
-	unsigned char buffer[std::max(sizeof(GCC_RTTI::__vtable_info), sizeof(GCC_RTTI::type_info))];
+	size_t size = (std::max)(sizeof(GCC_RTTI::__vtable_info), sizeof(GCC_RTTI::type_info));
+	unsigned char buffer[(std::max)(sizeof(GCC_RTTI::__vtable_info), sizeof(GCC_RTTI::type_info))];
 
 	ea_t startEA = ((seg->start_ea + sizeof(ea_t)) & ~((ea_t)(sizeof(ea_t) - 1)));
 	ea_t endEA = (seg->end_ea - sizeof(ea_t));

--- a/src/HexRaysCodeXplorer/TypeReconstructor.cpp
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.cpp
@@ -539,7 +539,9 @@ tid_t type_builder_t::get_structure(const qstring& name)
 
 						member_t * membr = get_member_by_name(struc, fncstr);
 						if (membr != NULL) {
-							tinfo_t new_type = create_typedef(vftbl_name.c_str());
+							qstring real_vftbl_name = vftbl_name;
+							real_vftbl_name += "::vtable";
+							tinfo_t new_type = create_typedef(real_vftbl_name.c_str());
 							if (new_type.is_correct()) {
 								smt_code_t dd = set_member_tinfo(struc, membr, 0, make_pointer(new_type), SET_MEMTI_COMPATIBLE);
 							}


### PR DESCRIPTION
- std::max is invalid in VS, due to max being defined as a macro, wrapping it in ()'s prevents the macro from running
- vtable names get "::vtable" appended to them in the create_vtbl_struct call, so when calling create_typedef, it fails
- The microcode view hotkey was incorrectly using the CTREE_EXPLORER hotkey