### PR TITLE
Remove assert from GCCObjectFormatParser to avoid crash

### DIFF
--- a/src/HexRaysCodeXplorer/GCCObjectFormatParser.cpp
+++ b/src/HexRaysCodeXplorer/GCCObjectFormatParser.cpp
@@ -305,7 +305,7 @@ void buildReconstructableTypesRecursive(GCCTypeInfo *type,  std::set <GCCTypeInf
 	ReconstructableType *reType;
 	if (g_ReconstractedTypes.count(type->typeName)) {
 		reType = g_ReconstractedTypes[type->typeName];
-		assert(false); // probably we already visited this type, need to check it.
+		return;
 	}
 	else {
 		reType = ReconstructableType::getReconstructableType(type->typeName);


### PR DESCRIPTION
Attempts to open object explorer window for the 2nd time lead to the assertion error and crash