### PR TITLE
Fix build with idasdk7.6

### DIFF
--- a/src/HexRaysCodeXplorer/CodeXplorer.cpp
+++ b/src/HexRaysCodeXplorer/CodeXplorer.cpp
@@ -51,8 +51,10 @@ IObjectFormatParser *object_format_parser = nullptr;
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+#if IDA_SDK_VERSION < 760
 // Hex-Rays API pointer
 hexdsp_t *hexdsp = nullptr;
+#endif
 
 namespace {
 

--- a/src/HexRaysCodeXplorer/MicrocodeExtractor.cpp
+++ b/src/HexRaysCodeXplorer/MicrocodeExtractor.cpp
@@ -274,9 +274,11 @@ static ssize_t idaapi migr_callback(void* ud, const int code, va_list va)
 
 	switch (code)
 	{
+#if IDA_SDK_VERSION < 760
 	case grcode_user_gentext:
 		result = true;
 		break;
+#endif
 
 		// refresh user-defined graph nodes and edges
 	case grcode_user_refresh:
@@ -358,9 +360,11 @@ static ssize_t idaapi mgr_callback(void* ud, const int code, va_list va)
 
 	switch (code)
 	{
+#if IDA_SDK_VERSION < 760
 	case grcode_user_gentext:
 		result = true;
 		break;
+#endif
 
 		// refresh user-defined graph nodes and edges
 	case grcode_user_refresh:


### PR DESCRIPTION
Hello, this patch will allow to build and use the plugin for both IDA 7.6 and earlier IDA versions.