### PR TITLE
Support non-interactive type reconstruction (e.g. from script).

### DIFF
--- a/src/HexRaysCodeXplorer/CodeXplorer.cpp
+++ b/src/HexRaysCodeXplorer/CodeXplorer.cpp
@@ -748,14 +748,15 @@ struct codexplorer_ctx_t : public plugmod_t
 			term_hexrays_plugin();
 		}
 	}
-	virtual bool idaapi run(size_t) override;
+	virtual bool idaapi run(size_t arg) override;
 };
 
-bool idaapi codexplorer_ctx_t::run(size_t)
+
+
+bool idaapi codexplorer_ctx_t::run(size_t arg)
 {
-	// This function won't be called because our plugin is invisible (no menu
-	// item in the Edit, Plugins menu) because of PLUGIN_HIDE
-	return true;
+    auto reconstruct_type_params = *reinterpret_cast<reconstruct_type_params_t *>(arg);
+    return reconstruct_type(reconstruct_type_params);
 }
 
 //--------------------------------------------------------------------------

--- a/src/HexRaysCodeXplorer/TypeReconstructor.cpp
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.cpp
@@ -718,3 +718,22 @@ bool idaapi reconstruct_type(cfuncptr_t cfunc, const qstring& var_name, const qs
 
 	return bResult;
 }
+
+bool idaapi reconstruct_type(const reconstruct_type_params_t & params)
+{
+	auto func = get_func(params.func_ea);
+	if (!func) {
+		logmsg(ERROR, "Failed to get function at 0x%x...\n", params.func_ea);
+		return false;
+	}
+
+    // Decompile.
+    hexrays_failure_t hf{};
+    auto cfunc = decompile(func, &hf);
+	if (!cfunc) {
+		logmsg(ERROR, "Failed to decompile function at 0x%x...\n", params.func_ea);
+		return false;
+	}
+
+	return reconstruct_type(cfunc, params.var_name, params.type_name);
+}

--- a/src/HexRaysCodeXplorer/TypeReconstructor.h
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.h
@@ -48,5 +48,13 @@ typedef std::vector<UCHAR>			BUFFER;
 bool idaapi reconstruct_type_cb(void *ud);
 bool idaapi reconstruct_type(cfuncptr_t cfunc, const qstring& var_name, const qstring& type_name);
 
+struct reconstruct_type_params_t
+{
+    ea_t func_ea;
+    char var_name[100];
+    char type_name[100];
+};
+
+bool idaapi reconstruct_type(const reconstruct_type_params_t & params);
 
 #endif


### PR DESCRIPTION
This addresses issue #98. Once merged in, clients written in Python could reconstruct structures non-interactively using the following snippet:

```
from ctypes import *
import ida_loader

class ReconstructionParams(Structure):
    _fields_ = [
        ('func_ea', c_uint64),
        ('var_name', c_char * 100),
        ('var_type', c_char * 100),
    ]
#                             address   var_name      var_type		 
params = ReconstructionParams(0x2754, b'CommBuffer', 'CommBuffer_2754')
ida_loader.load_and_run_plugin('HexRaysCodeXplorer64', addressof(params))
```

As a result, the following type would appear in the 'Structures' sub-menu:
![image](https://user-images.githubusercontent.com/8438963/132097314-7a4461af-4917-4509-93b2-c1c157e32134.png)
