### PR TITLE
Keep updating the 'is_pointer' attribute.

### DIFF
--- a/src/HexRaysCodeXplorer/TypeReconstructor.cpp
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.cpp
@@ -487,6 +487,12 @@ int idaapi type_builder_t::visit_expr(cexpr_t *e)
 				if (!ret.second && str_fld.vftbl != BADADDR) {
 					structure[str_fld.offset] = str_fld;
 				}
+
+				// we want to keep updating the 'is_pointer' attribute in case the
+				// first access to the member did not identify it as a pointer.
+				if (str_fld.is_pointer) {
+					structure[str_fld.offset].is_pointer = true;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Keep updating the `is_pointer` attribute in case the first access to the member did not identify it as a pointer. This can happen in case the **first** reference to the member is not casted to a `type **` expression.

![image](https://user-images.githubusercontent.com/8438963/132961466-c3ddabdd-8ca8-498b-9ce7-2c5d14a7b690.png)

Attached below is a module to trigger this behavior in the current implementation (should be fixed once the PR is merged):
[e90a7b5e-37b2-43e4-b281-4c8e349045e9.zip](https://github.com/REhints/HexRaysCodeXplorer/files/7148514/e90a7b5e-37b2-43e4-b281-4c8e349045e9.zip)