### PR TITLE
Minor changes to MacOS makefile for IDA 7.7 SDK

### DIFF
--- a/src/HexRaysCodeXplorer/makefile7.mac
+++ b/src/HexRaysCodeXplorer/makefile7.mac
@@ -2,7 +2,7 @@ CXX ?= clang++
 MACSDK=$(shell xcrun --show-sdk-path --sdk macosx)
 CXXFLAGS=-m64 -fPIC -shared  -D__PLUGIN__  -D__X64__ -Wall -Wextra -std=c++11 -isysroot $(MACSDK) -static-libstdc++ -DUSE_DANGEROUS_FUNCTIONS=1 -DUSE_STANDARD_FILE_FUNCTIONS=1
 LDFLAGS=-shared -m64
-LIBS=-lc -lpthread -ldl -lpro -lc++ -liconv
+LIBS=-lc -lpthread -ldl -lc++ -liconv
 INCLUDES=-I$(IDA_SDK)/include -I$(IDA_DIR)/plugins/hexrays_sdk/include
 
 SRCDIR=./
@@ -35,7 +35,7 @@ HexRaysCodeXplorer64.dylib: $(SRC)
 	$(CXX) $(LDFLAGS) $(SRC) $(CXXFLAGS) -L. -L$(IDA_DIR) $(INCLUDES) -D__MAC__=1 -D__EA64__=1 $(LIBS) -lida64 -o HexRaysCodeXplorer64.dylib
 
 clean:
-	rm -f HexRaysCodeXplorer.dylib HexRaysCodeXplorer64.dylib libpro.a
+	rm -f HexRaysCodeXplorer.dylib HexRaysCodeXplorer64.dylib 
 
 install:
 	cp -f HexRaysCodeXplorer.dylib $(IDA_DIR)/plugins/
@@ -48,6 +48,6 @@ endif
 ifndef IDA_DIR
     $(error IDA_DIR is undefined)
 endif
-	pwd && cp -f $(IDA_SDK)/lib/x64_mac_clang_64/pro.a libpro.a
+#	pwd && cp -f $(IDA_SDK)/lib/x64_mac_clang_64/pro.a libpro.a
 
 .PHONY: check-env


### PR DESCRIPTION
Removes references to libpro from MacOS makefile that prevent building; tested with IDA 7.7 SDK and builds/runs fine.