### PR TITLE
add include path for new IDA pro sdk

### DIFF
--- a/src/HexRaysCodeXplorer.xcodeproj/project.pbxproj
+++ b/src/HexRaysCodeXplorer.xcodeproj/project.pbxproj
@@ -3705,6 +3705,8 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(IDA_SDK)/lib/x64_mac_gcc_32/",
 					"$(IDA_SDK)/lib/x64_mac_gcc_64/",
+					"$(IDA_SDK)/lib/x64_mac_gcc_32_pro/",
+					"$(IDA_SDK)/lib/x64_mac_gcc_64_pro/",
 					"$(IDA_SDK)/lib/",
 				);
 				OTHER_CFLAGS = "";
@@ -3743,6 +3745,8 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(IDA_SDK)/lib/x64_mac_gcc_32/",
 					"$(IDA_SDK)/lib/x64_mac_gcc_64/",
+					"$(IDA_SDK)/lib/x64_mac_gcc_32_pro/",
+					"$(IDA_SDK)/lib/x64_mac_gcc_64_pro/",
 					"$(IDA_SDK)/lib/",
 				);
 				OTHER_CFLAGS = "";
@@ -3884,6 +3888,8 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(IDA_SDK)/lib/x64_mac_gcc_32/",
 					"$(IDA_SDK)/lib/x64_mac_gcc_64/",
+					"$(IDA_SDK)/lib/x64_mac_gcc_32_pro/",
+					"$(IDA_SDK)/lib/x64_mac_gcc_64_pro/",
 					"$(IDA_SDK)/lib/",
 				);
 				OTHER_CFLAGS = "";
@@ -3922,6 +3928,8 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(IDA_SDK)/lib/x64_mac_gcc_32/",
 					"$(IDA_SDK)/lib/x64_mac_gcc_64/",
+					"$(IDA_SDK)/lib/x64_mac_gcc_32_pro/",
+					"$(IDA_SDK)/lib/x64_mac_gcc_64_pro/",
 					"$(IDA_SDK)/lib/",
 				);
 				OTHER_CFLAGS = "";

--- a/src/HexRaysCodeXplorer/HexRaysCodeXplorer.vcxproj
+++ b/src/HexRaysCodeXplorer/HexRaysCodeXplorer.vcxproj
@@ -117,7 +117,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>ida.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/EXPORT:PLUGIN %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalLibraryDirectories>$(IDASDK)\lib\x64_win_vc_32</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(IDASDK)\lib\x64_win_vc_32;$(IDASDK)\lib\x64_win_vc_32_pro</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug x64|x64'">
@@ -135,7 +135,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>ida.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/EXPORT:PLUGIN %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalLibraryDirectories>$(IDASDK)\lib\x64_win_vc_64</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(IDASDK)\lib\x64_win_vc_64;$(IDASDK)\lib\x64_win_vc_64_pro</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -158,7 +158,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>ida.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/EXPORT:PLUGIN %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalLibraryDirectories>$(IDASDK)\lib\x64_win_vc_32</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(IDASDK)\lib\x64_win_vc_32;$(IDASDK)\lib\x64_win_vc_32_pro</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">
@@ -181,7 +181,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>ida.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/EXPORT:PLUGIN %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalLibraryDirectories>$(IDASDK)\lib\x64_win_vc_64</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(IDASDK)\lib\x64_win_vc_64;$(IDASDK)\lib\x64_win_vc_64_pro</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/cmake/FindIdaSdk.cmake
+++ b/src/cmake/FindIdaSdk.cmake
@@ -106,6 +106,24 @@ function(_ida_common_target_settings t ea64)
   target_include_directories(${t} PUBLIC ${IdaSdk_INCLUDE_DIRS})
 endfunction()
 
+function(_ida_win_link_library)
+  if(ea64)
+    set(target_bits 64)
+  else()
+    set(target_bits 32)
+  endif()
+
+  if(EXISTS ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits}_pro)
+    set(ida_lib_dir ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits}_pro)
+  elseif(EXISTS ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits})
+    set(ida_lib_dir ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits})
+  else()
+    message(FATAL_ERROR "IDA SDK lib directory not found")
+  endif()
+
+  target_link_libraries(${t} ${ida_lib_dir}/ida.lib)
+endfunction()
+
 function(_ida_plugin name ea64 link_script) # ARGN contains sources
   if(ea64)
     set(t ${name}${_so64})
@@ -133,19 +151,7 @@ function(_ida_plugin name ea64 link_script) # ARGN contains sources
     # TODO(cblichmann): This belongs in an interface library instead.
     target_compile_options(${t} PUBLIC -Wno-non-virtual-dtor -Wno-varargs)
   elseif(WIN32)
-    if(ea64)
-      set(target_bits 64)
-    else()
-      set(target_bits 32)
-    endif()
-
-    if(exists ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits}_pro)
-      set(ida_lib_dir ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits}_pro)
-    elseif(exists ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits})
-      set(ida_lib_dir ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits})
-    endif()
-
-    target_link_libraries(${t} ${ida_lib_dir}/ida.lib)
+    _ida_win_link_library()
   endif()
 endfunction()
 
@@ -176,11 +182,7 @@ function(_ida_loader name ea64 link_script)
     # TODO(cblichmann): This belongs in an interface library instead.
     target_compile_options(${t} PUBLIC -Wno-non-virtual-dtor -Wno-varargs)
   elseif(WIN32)
-    if(ea64)
-      target_link_libraries(${t} ${IdaSdk_DIR}/lib/x64_win_vc_64/ida.lib)
-    else()
-      target_link_libraries(${t} ${IdaSdk_DIR}/lib/x64_win_vc_32/ida.lib)
-    endif()
+    _ida_win_link_library()
     target_link_options(${t} PUBLIC "/EXPORT:LDSC")
   endif()
 endfunction()

--- a/src/cmake/FindIdaSdk.cmake
+++ b/src/cmake/FindIdaSdk.cmake
@@ -134,10 +134,18 @@ function(_ida_plugin name ea64 link_script) # ARGN contains sources
     target_compile_options(${t} PUBLIC -Wno-non-virtual-dtor -Wno-varargs)
   elseif(WIN32)
     if(ea64)
-      target_link_libraries(${t} ${IdaSdk_DIR}/lib/x64_win_vc_64/ida.lib)
+      set(target_bits 64)
     else()
-      target_link_libraries(${t} ${IdaSdk_DIR}/lib/x64_win_vc_32/ida.lib)
+      set(target_bits 32)
     endif()
+
+    if(exists ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits}_pro)
+      set(ida_lib_dir ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits}_pro)
+    elseif(exists ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits})
+      set(ida_lib_dir ${IdaSdk_DIR}/lib/x64_win_vc_${target_bits})
+    endif()
+
+    target_link_libraries(${t} ${ida_lib_dir}/ida.lib)
   endif()
 endfunction()
 


### PR DESCRIPTION
The path to `*.lib`s in IDA Pro SDK has apparently changed since 8.0. Added the new path to cmake, VS project and Xcode project so people with new SDK won't need to manually add those paths.