### PR TITLE
Modernize build with C++23 helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ __Compiling__:
 * mkdir build && cd build
 * cmake .. -DIdaSdk_ROOT_DIR=<PATH_TO_IDA_SDK> -DHexRaysSdk_ROOT_DIR=<PATH_TO_HEXRAYS_SDK>
 * cmake --build . --config Release
+* or simply run `python3 ../../build.py --ida <PATH_TO_IDA_SDK> --hexrays <PATH_TO_HEXRAYS_SDK>`
 
 ============================================================================
 

--- a/build.py
+++ b/build.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build HexRaysCodeXplorer plugin")
+    parser.add_argument("--ida", required=True, help="Path to IDA SDK")
+    parser.add_argument("--hexrays", required=True, help="Path to HexRays SDK")
+    parser.add_argument("--build-dir", default="build", help="Directory for build files")
+    parser.add_argument("--config", default="Release", help="Build type")
+    args = parser.parse_args()
+
+    build_dir = os.path.abspath(args.build_dir)
+    os.makedirs(build_dir, exist_ok=True)
+
+    cmake_cmd = [
+        "cmake",
+        "..",
+        f"-DIdaSdk_ROOT_DIR={args.ida}",
+        f"-DHexRaysSdk_ROOT_DIR={args.hexrays}",
+    ]
+    subprocess.check_call(cmake_cmd, cwd=build_dir)
+
+    build_cmd = ["cmake", "--build", ".", "--config", args.config]
+    subprocess.check_call(build_cmd, cwd=build_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/HexRaysCodeXplorer/CMakeLists.txt
+++ b/src/HexRaysCodeXplorer/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.7)
 
 project(HexRaysCodeXplorer CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(APPLE)
@@ -61,7 +62,7 @@ set(src
 
 add_ida_plugin(HexRaysCodeXplorer ${PROJECT_SOURCE_DIR}/CodeXplorer.cpp)
 
-set_ida_target_properties(HexRaysCodeXplorer PROPERTIES CXX_STANDARD 17)
+set_ida_target_properties(HexRaysCodeXplorer PROPERTIES CXX_STANDARD 23)
 ida_target_include_directories(HexRaysCodeXplorer PRIVATE
                                ${IdaSdk_INCLUDE_DIRS})
 

--- a/src/HexRaysCodeXplorer/CtreeExtractor.cpp
+++ b/src/HexRaysCodeXplorer/CtreeExtractor.cpp
@@ -217,11 +217,11 @@ int get_hash_of_string(const qstring &string_to_hash, qstring &hash) {
 	uint8_t message_digest[SHA1HashSize];
 
 	auto err = SHA1Reset(&sha);
-	if (err == shaSuccess) {
+	if (err == ShaResult::Success) {
 		err = SHA1Input(&sha, (uint8_t *)string_to_hash.c_str(), static_cast<unsigned>(string_to_hash.length()));
-		if (err == shaSuccess) {
+		if (err == ShaResult::Success) {
 			err = SHA1Result(&sha, message_digest);
-			if (err == shaSuccess) {
+			if (err == ShaResult::Success) {
 				char digest_hex[SHA1HashSize * 2 + 1];
 				memset(digest_hex, 0x00, sizeof(digest_hex));
 				SHA1MessageDigestToString(message_digest, digest_hex);
@@ -249,14 +249,14 @@ void dump_ctrees_in_file(std::map<ea_t, ctree_dump_line> &data_to_dump, const qs
 
 		qstring sha_hash;
 		auto err = get_hash_of_string(cdl.ctree_for_hash, sha_hash);
-		if (err != shaSuccess) {
+		if (err != ShaResult::Success) {
 			logmsg(ERROR, "Error in computing SHA1 hash\r\n");
 			continue;
 		}
 
 		auto dump_line = sha_hash + ";";
 		err = get_hash_of_string(cdl.ctree_dump, sha_hash);
-		if (err != shaSuccess) {
+		if (err != ShaResult::Success) {
 			logmsg(ERROR, "Error in computing SHA1 hash\r\n");
 			continue;
 		}

--- a/src/HexRaysCodeXplorer/ObjectExplorer.h
+++ b/src/HexRaysCodeXplorer/ObjectExplorer.h
@@ -129,6 +129,6 @@ bool get_text_disasm(ea_t ea, qstring& rv);
 
 bool get_vbtbl_by_ea(ea_t vtbl_addr, VTBL_info_t &vtbl);
 
-tid_t create_vtbl_struct(ea_t vtbl_addr, ea_t vtbl_addr_end, const qstring& vtbl_name, uval_t idx, unsigned int* vtbl_len = NULL);
+tid_t create_vtbl_struct(ea_t vtbl_addr, ea_t vtbl_addr_end, const qstring& vtbl_name, uval_t idx, unsigned int* vtbl_len = nullptr);
 
 #endif

--- a/src/HexRaysCodeXplorer/TypeExtractor.cpp
+++ b/src/HexRaysCodeXplorer/TypeExtractor.cpp
@@ -63,7 +63,7 @@ int idaapi obj_fint_t::visit_expr(cexpr_t *e)
 
 	// get the variable name
 	qstring s;
-	print1wrapper(e, &s, NULL);
+	print1wrapper(e, &s, nullptr);
 	tag_remove(&s);
 
 	// check for the target variable
@@ -80,12 +80,12 @@ int idaapi obj_fint_t::visit_expr(cexpr_t *e)
 		if (parent->is_expr() && parent->op == cot_asg) {
 			cexpr_t * target_expr = (cexpr_t *)parent;
 
-			while (target_expr->x != NULL && target_expr->op != cot_var && target_expr->op != cot_obj)
+			while (target_expr->x != nullptr && target_expr->op != cot_var && target_expr->op != cot_obj)
 				target_expr = target_expr->x;
 
 			if (target_expr->op == cot_var) {
 				s.clear();
-				print1wrapper(target_expr, &s, NULL);
+				print1wrapper(target_expr, &s, nullptr);
 				tag_remove(&s);
 
 				var_name = s;
@@ -99,22 +99,20 @@ int idaapi obj_fint_t::visit_expr(cexpr_t *e)
 }
 
 void idaapi reset_pointer_type(cfuncptr_t cfunc, const qstring &var_name) {
-	lvars_t * locals = cfunc->get_lvars();
-	if (locals == NULL)
-		return;
+        lvars_t * locals = cfunc->get_lvars();
+        if (locals == nullptr)
+                return;
 
-	qvector<lvar_t>::iterator locals_iter;
+        for (auto &local : *locals) {
+                if (var_name != local.name)
+                        continue;
 
-	for (locals_iter = locals->begin(); locals_iter != locals->end(); locals_iter++) {
-		if (var_name != locals_iter->name)
-			continue;
-
-		tinfo_t int_type = tinfo_t(BT_INT32);
-		locals_iter->set_final_lvar_type(int_type);
-		locals_iter->set_user_type();
-		cfunc->build_c_tree();
-		break;
-	}
+                tinfo_t int_type = tinfo_t(BT_INT32);
+                local.set_final_lvar_type(int_type);
+                local.set_user_type();
+                cfunc->build_c_tree();
+                break;
+        }
 }
 
 bool idaapi find_var(void *ud)
@@ -123,9 +121,9 @@ bool idaapi find_var(void *ud)
 
 	// Determine the ctree item to highlight
 	vu.get_current_item(USE_KEYBOARD);
-	citem_t *highlight = vu.item.is_citem() ? vu.item.e : NULL;
+	citem_t *highlight = vu.item.is_citem() ? vu.item.e : nullptr;
 
-	// highlight == NULL might happen if one chooses variable at local variables declaration statement
+	// highlight == nullptr might happen if one chooses variable at local variables declaration statement
 	if (!highlight)
 	{
 		logmsg(DEBUG, "Invalid item is choosen");
@@ -138,7 +136,7 @@ bool idaapi find_var(void *ud)
 		cexpr_t *highl_expr = (cexpr_t *)highlight;
 
 		qstring s;
-		print1wrapper(highlight, &s, NULL);
+		print1wrapper(highlight, &s, nullptr);
 		tag_remove(&s);
 
 		// initialize type rebuilder
@@ -146,7 +144,7 @@ bool idaapi find_var(void *ud)
 		obj_find.vtbl_name = s;
 
 		// traverse the ctree structure
-		obj_find.apply_to(&vu.cfunc->body, NULL);
+		obj_find.apply_to(&vu.cfunc->body, nullptr);
 
 		if (obj_find.bFound) {
 			logmsg(DEBUG, (obj_find.var_name + "\n").c_str());
@@ -173,7 +171,7 @@ bool idaapi find_var(cfuncptr_t cfunc, const qstring& vtbl_name, qstring &var_na
 		obj_find.vtbl_name.remove(0, 6);
 
 	// traverse the ctree structure
-	obj_find.apply_to(&cfunc->body, NULL);
+	obj_find.apply_to(&cfunc->body, nullptr);
 
 	if (!obj_find.bFound) {
 		logmsg(DEBUG, "Failed to find variable...\n");
@@ -221,7 +219,7 @@ tid_t idaapi merge_types(const qvector<qstring>& types_to_merge, const qstring& 
 				}
 			} else {
 				int flag = Compat::get_member_flag(struc_id, offset);
-				Compat::add_struc_member(struc_id, member_name.c_str(), offset, flag, NULL, member_size);
+				Compat::add_struc_member(struc_id, member_name.c_str(), offset, flag, nullptr, member_size);
 			}
 
 			offsets.insert(offset);
@@ -286,7 +284,7 @@ void idaapi dump_type_info(int file_id, const VTBL_info_t& vtbl_info, const qstr
 	qstring file_entry_val;
 	tinfo_t new_type = create_typedef(type_name.c_str());
 
-	if (new_type.is_correct() && new_type.print(&file_entry_val, NULL, PRTYPE_DEF | PRTYPE_1LINE)) {
+	if (new_type.is_correct() && new_type.print(&file_entry_val, nullptr, PRTYPE_DEF | PRTYPE_1LINE)) {
 		qstring line;
 
 		line = key_hash + ";" + file_entry_key + ";";
@@ -375,7 +373,7 @@ bool idaapi extract_all_types(void *ud)
 
 			hexrays_failure_t hf;
 			cfuncptr_t cfunc = decompile(pfn, &hf);
-			if (cfunc != NULL) {
+			if (cfunc != nullptr) {
 				qstring var_name;
 				info_msg.clear();
 

--- a/src/HexRaysCodeXplorer/Utility.cpp
+++ b/src/HexRaysCodeXplorer/Utility.cpp
@@ -86,10 +86,10 @@ void split_qstring(const qstring &options, const qstring &splitter, qvector<qstr
 void SHA1PadMessage(SHA1Context *);
 void SHA1ProcessMessageBlock(SHA1Context *);
 
-int SHA1Reset(SHA1Context *context)
+ShaResult SHA1Reset(SHA1Context *context)
 {
 	if (!context)
-		return shaNull;
+		return ShaResult::Null;
 
 	context->Length_Low = 0;
 	context->Length_High = 0;
@@ -101,14 +101,14 @@ int SHA1Reset(SHA1Context *context)
 	context->Intermediate_Hash[4] = 0xC3D2E1F0;
 	context->Computed = 0;
 	context->Corrupted = 0;
-	return shaSuccess;
+	return ShaResult::Success;
 }
 
-int SHA1Result(SHA1Context *context, uint8_t Message_Digest[SHA1HashSize])
+ShaResult SHA1Result(SHA1Context *context, uint8_t Message_Digest[SHA1HashSize])
 {
 	int i;
 	if (!context || !Message_Digest)
-		return shaNull;
+		return ShaResult::Null;
 	
 	if (context->Corrupted)
 		return context->Corrupted;
@@ -126,23 +126,23 @@ int SHA1Result(SHA1Context *context, uint8_t Message_Digest[SHA1HashSize])
 	for (i = 0; i < SHA1HashSize; ++i)
 		Message_Digest[i] = context->Intermediate_Hash[i >> 2] >> 8 * (3 - (i & 0x03));
 
-	return shaSuccess;
+	return ShaResult::Success;
 }
 
-int SHA1Input(SHA1Context *context, const uint8_t *message_array, unsigned int length)
+ShaResult SHA1Input(SHA1Context *context, const uint8_t *message_array, unsigned int length)
 {
 	if (!length)
 	{
-		return shaSuccess;
+		return ShaResult::Success;
 	}
 	if (!context || !message_array)
 	{
-		return shaNull;
+		return ShaResult::Null;
 	}
 	if (context->Computed)
 	{
-		context->Corrupted = shaStateError;
-		return shaStateError;
+		context->Corrupted = ShaResult::StateError;
+		return ShaResult::StateError;
 	}
 	if (context->Corrupted)
 	{
@@ -163,7 +163,7 @@ int SHA1Input(SHA1Context *context, const uint8_t *message_array, unsigned int l
 			SHA1ProcessMessageBlock(context);
 		message_array++;
 	}
-	return shaSuccess;
+	return ShaResult::Success;
 }
 
 void SHA1ProcessMessageBlock(SHA1Context *context)

--- a/src/HexRaysCodeXplorer/Utility.h
+++ b/src/HexRaysCodeXplorer/Utility.h
@@ -48,13 +48,15 @@ bool idaapi show_string_in_custom_view(void *ud, const qstring& title, const qst
 //#define SIZESTR(x) (sizeof(x) - 1)
 
 #ifndef _countof
-#	define _countof(x) (sizeof((x)) / sizeof((x)[0]))
+template <typename T, size_t N>
+constexpr size_t countof(const T (&)[N]) noexcept { return N; }
+#   define _countof(x) countof(x)
 #endif // _countof
 
 
-typedef qlist<ea_t> eaList;
-typedef std::set<ea_t> eaSet;
-typedef std::map<ea_t, UINT> eaRefMap;
+using eaList = qlist<ea_t>;
+using eaSet = std::set<ea_t>;
+using eaRefMap = std::map<ea_t, UINT>;
 struct earef
 {
 	ea_t ea;
@@ -106,17 +108,17 @@ inline bool isEa(flags_t f)
 
 #ifndef _SHA_enum_
 #define _SHA_enum_
-enum
+enum class ShaResult
 {
-	shaSuccess = 0,
-	shaNull,  // Null pointer parameter
-	shaInputTooLong, // input data too long
-	shaStateError // called Input after Result
+        Success = 0,
+        Null,  // Null pointer parameter
+        InputTooLong, // input data too long
+        StateError // called Input after Result
 };
 #endif
 #define SHA1HashSize 20
 
-typedef struct SHA1Context
+struct SHA1Context
 {
 	uint32_t Intermediate_Hash[SHA1HashSize / 4]; // Message Digest
 	uint32_t Length_Low; // Message length in bits
@@ -125,12 +127,12 @@ typedef struct SHA1Context
 	int_least16_t Message_Block_Index;
 	uint8_t Message_Block[64]; // 512-bit message blocks
 	int Computed; // Is the digest computed?
-	int Corrupted; // Is the message digest corrupted?
-} SHA1Context;
+        int Corrupted; // Is the message digest corrupted?
+};
 
-int SHA1Reset(SHA1Context *);
-int SHA1Input(SHA1Context *, const uint8_t *, unsigned int);
-int SHA1Result(SHA1Context *, uint8_t Message_Digest[SHA1HashSize]);
+ShaResult SHA1Reset(SHA1Context *);
+ShaResult SHA1Input(SHA1Context *, const uint8_t *, unsigned int);
+ShaResult SHA1Result(SHA1Context *, uint8_t Message_Digest[SHA1HashSize]);
 void SHA1MessageDigestToString(uint8_t Message_Digest[SHA1HashSize], char outbuffer[SHA1HashSize * 2]);
 
 void split_qstring(const qstring &options, const qstring &splitter, qvector<qstring> &result);


### PR DESCRIPTION
## Summary
- add a Python build helper similar to efiXplorer
- disable compiler extensions and require C++23
- document helper script usage
- modernize pointer default in ObjectExplorer API

## Testing
- `cmake ../src/HexRaysCodeXplorer` *(fails: IDA SDK not found)*