### PR TITLE
Fix IDA 9.0 build errors

### DIFF
--- a/src/HexRaysCodeXplorer/Common.h
+++ b/src/HexRaysCodeXplorer/Common.h
@@ -27,16 +27,8 @@
 
 #pragma once
 
-#if !defined (__LINUX__) && !defined (__MAC__)
-    #ifdef __MAKEDLL__
-    #  define DLLEXPORT __declspec(dllexport)
-    #else
-    #  define DLLEXPORT __declspec(dllimport)
-    #endif
-#else
-    #define DLLEXPORT
-#endif
 
+#define DLLEXPORT
 
 
 

--- a/src/HexRaysCodeXplorer/ReconstructableType.cpp
+++ b/src/HexRaysCodeXplorer/ReconstructableType.cpp
@@ -686,10 +686,8 @@ ssize_t hook_idb_events(void *user_data, int notification_code, va_list va) {
 	tid_t tid{};
 	const char *oldname;
 	const char *newname;
-	struc_t *struc;
 	ea_t ea;
 	adiff_t diff;
-	member_t *member;
 	flags_t flags;
 	const opinfo_t *info;
 	asize_t size;


### PR DESCRIPTION
## Fix IDA 9.0 build errors on Windows

### Problem
The plugin fails to build on IDA SDK 9.0 with the following errors:
1. `struc_t` and `member_t` undefined (removed in IDA 9.0)
2. Linker errors with `__declspec(dllimport)` symbols

### Solution
1. **Removed unused variables** (lines 689, 692 in ReconstructableType.cpp)
   - These variables were declared but never used
   - Safe to remove on all platforms

2. **Simplified DLLEXPORT macro** (Common.h)
   - The macro was causing linker errors due to incorrect dllimport
   - IDA plugins don't need dllexport/dllimport
   - Cross-platform compatible

### Testing
- ✅ Successfully builds on Windows with IDA SDK 9.0
- ✅ All plugin features work correctly in IDA Pro 9.0
- ✅ Changes don't affect Linux/Mac builds

### Related Issues
Fixes #120 (IDA 9.0 Support)
Complements #121 (builds on top of @BowDown097's work)